### PR TITLE
- Adding in ONBUILD option for 3.4.0

### DIFF
--- a/3.4.0-onbuild/Dockerfile
+++ b/3.4.0-onbuild/Dockerfile
@@ -1,0 +1,42 @@
+FROM node:4.7-alpine
+
+MAINTAINER Cedric Hurst <cedric@spantree.net>
+
+ENV REVEAL_VERSION 3.4.0
+ENV NPM_CACHE_DIR /var/cache/npm
+
+WORKDIR /usr/src/slides
+
+RUN apk -U add \
+    git \
+    python \
+    ruby \
+    su-exec \
+ && apk -U add --virtual build-dependencies \
+    alpine-sdk \
+ && gem install --no-document sass \
+ && npm install -g \
+    bower \
+    generator-reveal \
+    grunt-cli \
+    node-sass \
+    npm-cache \
+    yo \
+ && curl -L "https://github.com/hakimel/reveal.js/tarball/${REVEAL_VERSION}" | tar xvz \
+ && mkdir -p $NPM_CACHE_DIR \
+ && chown -R node $NPM_CACHE_DIR \
+ && npm-cache install \
+ && apk del build-dependencies \
+ && rm -rf /var/cache/apk/*
+
+ONBUILD ADD package.json /usr/src/slides
+ONBUILD RUN npm install
+ONBUILD ADD bower.json /usr/src/slides
+ONBUILD ADD .bowerrc /usr/src/slides
+ONBUILD RUN bower install --allow-root
+ONBUILD ADD . /usr/src/slides
+ONBUILD RUN grunt build
+
+EXPOSE 9000
+
+CMD ["grunt", "serve"]

--- a/3.4.0-onbuild/README.md
+++ b/3.4.0-onbuild/README.md
@@ -1,0 +1,59 @@
+# Overview
+This Dockerfile is a building block for creating reusable Reveal presentations that are self-contained and easily distributable.  The goals of this are two fold: 
+
+* Provide an easy distribution platform for Reveal presentations (Cache runtime and build dependencies)
+* Allow for rapid iteration of the slides themselves when in "hack" mode
+
+## Example Usage
+Build the base container or pull from public registry: 
+```
+docker build -t spantree/reveal:3.4.0-onbuild .
+```
+
+Build an actual slide deck leveraging base build: (ex. https://github.com/Spantree/elasticsearch-talk)
+```
+git clone https://github.com/Spantree/elasticsearch-talk ~/elasticsearch-talk
+cd ~/elasticsearch-talk/slides
+echo FROM spantree/reveal:3.4.0-onbuild > Dockerfile
+docker build -t estalk .
+```
+
+**NOTE:** At this point, we have a local image tagged `estalk` that contains a set of all dependencies, slides, etc. that can simply be run! 
+
+### Run the talk in presentation mode: 
+Run the encapsulated presentation locally. 
+
+```
+docker run -it --rm -p 9000:9000 --name estalk estalk
+```
+
+### Run in development mode: 
+Run the presentation locally with the slides mounted to allow for quick & iterative development. 
+
+```
+docker run -rm --it -p 9000:9000 -v $(pwd)/slides:/usr/src/slides/slides estalk
+# Hack hack hack on slides
+# Reload browser
+# ... 
+# profit
+```
+
+**NOTE:** Because of the `ONBUILD` directives, if there are actual changes you want to make to the dependencies (package.json or bower.json) or the build process itself (Gruntfile) you should `rebuild` the image to ensure you have a consistent and repeatable build!
+
+## Requirements
+The Dockerfile works by making several assumptions of the projects that will utilize it.  It utilizes the `ONBUILD` directive that is available to all Docker containers.  
+
+As a consumer (ex. `FROM spantree/reveal:3.4.0-onbuild`), presentation developers simply need to follow a few conventions: 
+
+### File Requirements
+* `package.json` - Standard NPM formatted file with all the requirements defined
+* `bower.json` - Front end dependencies to be pulled via Bower
+* `.bowerrc` - Bower configuration file (build will fail if something is not present)
+
+### Grunt Configuration 
+The `ONBUILD` and `CMD` expect a few things from the Grunt configuration. 
+
+Targets: 
+* `build` - called once during the actual build phase.  This target should perform any necessary steps to prepare the actual presentation for distribution. 
+* `serve` - called at "runtime" of the container.  This should actually serve up the on `PORT 9000`
+

--- a/3.4.0-onbuild/docker-compose.yml
+++ b/3.4.0-onbuild/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  reveal:
+    build: .
+    volumes:
+      - ./slides:/usr/src/slides/slides
+    ports:
+      - "9000:9000"


### PR DESCRIPTION
Now instead of re-downloading the node modules via the entrypoint, these are done in the build step and are cached unless something changes.